### PR TITLE
fix: add react as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15",
-    "react": "*"
+    "react": ">=15"
   },
   "files": [
     "build"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "jsdoc-to-markdown": "^5.0.0"
   },
   "peerDependencies": {
-    "prop-types": "^15"
+    "prop-types": "^15",
+    "react": "*"
   },
   "files": [
     "build"


### PR DESCRIPTION
When `yarn` is used in PnP mode it requires that all used dependencies be explicitly specified in package.json.  That revealed that `prop-types` uses `react` but doesn't specify any kind of dependency on `react`.  Since we just use `React.Children` I think it's probably fine to use `*` as a peerDep here, but we could also specify a minimum version (16?) if we wanted to.