### PR TITLE
feat: add custom prop types to propTypes object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,16 @@
-export { arrayWithLength } from './arrayWithLength'
-export { instanceOfComponent } from './instanceOfComponent'
-export { mutuallyExclusive } from './mutuallyExclusive'
+import propTypes from 'prop-types'
+
+import { arrayWithLength } from './arrayWithLength.js'
+import { instanceOfComponent } from './instanceOfComponent.js'
+import { mutuallyExclusive } from './mutuallyExclusive.js'
+
+const customPropTypes = {
+    arrayWithLength,
+    instanceOfComponent,
+    mutuallyExclusive,
+}
+
+export default {
+    ...propTypes,
+    ...customPropTypes,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ const customPropTypes = {
     mutuallyExclusive,
 }
 
+export { arrayWithLength, instanceOfComponent, mutuallyExclusive }
+
 export default {
     ...propTypes,
     ...customPropTypes,


### PR DESCRIPTION
This should address https://github.com/dhis2/prop-types/issues/38, but in a slightly different way. We now only expose the default export (propTypes) and make sure our custom propTypes are attached. Let me know if you guys would prefer to also expose the individual custom prop-types here...

Fixes #38.