### PR TITLE
feat: introduce forbidUnknowProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ yarn add @dhis2/prop-types
 <dd><p>Ensure the prop value is an array with a length between a minimum and maximum.
 If a third <code>propType</code> argument is passed each item in the array needs to be of that prop-type</p>
 </dd>
-<dt><a href="#forbidUnknowProps">forbidUnknowProps(propTypes)</a> ⇒ <code>Object</code></dt>
+<dt><a href="#whitelistProps">whitelistProps(propTypes)</a> ⇒ <code>Object</code></dt>
 <dd><p>Ensure that no other props, apart from the ones in the prop-types definition
 have been passed tot the component</p>
 </dd>
@@ -58,15 +58,15 @@ LotsOfLists.propTypes = {
     mandatoryArrayBetweenOneAndTen: arrayWithLength(1,10).isRequired,
 }
 ```
-<a name="forbidUnknowProps"></a>
+<a name="whitelistProps"></a>
 
-## forbidUnknowProps(propTypes) ⇒ <code>Object</code>
+## whitelistProps(propTypes) ⇒ <code>Object</code>
 Ensure that no other props, apart from the ones in the prop-types definition
 have been passed tot the component
 
 **Kind**: global function  
 **Returns**: <code>Object</code> - Returns a copy of the original prop-types object with an appended
-property `forbidUnknowProps`, which is a prop-types validator that will return an error
+property `whitelistProps`, which is a prop-types validator that will return an error
 if props have been added that the component that were not in the prop-types object  
 
 | Param | Type | Description |
@@ -79,13 +79,13 @@ import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
 const MyComponent = ({ score, maxScore }) => <div>{score} out of {maxScore}</div>
-MyComponent.propTypes = propTypes.forbidUnknowProps({
+MyComponent.propTypes = propTypes.whitelistProps({
     score: propTypes.number,
     maxScore: propTypes.number,
 })
 
-Note: `forbidUnknowProps` is different from the `exact` method form the standard
-prop-types library, because `forbidUnknowProps` is meant to be applied on a full component
+Note: `whitelistProps` is different from the `exact` method form the standard
+prop-types library, because `whitelistProps` is meant to be applied on a full component
 prop-type definition, while `exact` is meant to be a applied on an individual prop-type
 ```
 <a name="instanceOfComponent"></a>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ yarn add @dhis2/prop-types
 <dd><p>Ensure the prop value is an array with a length between a minimum and maximum.
 If a third <code>propType</code> argument is passed each item in the array needs to be of that prop-type</p>
 </dd>
+<dt><a href="#forbidUnknowProps">forbidUnknowProps(propTypes)</a> ⇒ <code>Object</code></dt>
+<dd><p>Ensure that no other props, apart from the ones in the prop-types definition
+have been passed tot the component</p>
+</dd>
 <dt><a href="#instanceOfComponent">instanceOfComponent(Component)</a> ⇒ <code>Error</code> | <code>null</code></dt>
 <dd><p>Ensure the prop value is an instance of a certain component</p>
 </dd>
@@ -53,6 +57,36 @@ LotsOfLists.propTypes = {
     arrayWithAtLeastTenItems: arrayWithLength(10),
     mandatoryArrayBetweenOneAndTen: arrayWithLength(1,10).isRequired,
 }
+```
+<a name="forbidUnknowProps"></a>
+
+## forbidUnknowProps(propTypes) ⇒ <code>Object</code>
+Ensure that no other props, apart from the ones in the prop-types definition
+have been passed tot the component
+
+**Kind**: global function  
+**Returns**: <code>Object</code> - Returns a copy of the original prop-types object with an appended
+property `forbidUnknowProps`, which is a prop-types validator that will return an error
+if props have been added that the component that were not in the prop-types object  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| propTypes | <code>object</code> | The prop-types definition of the component |
+
+**Example**  
+```js
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+
+const MyComponent = ({ score, maxScore }) => <div>{score} out of {maxScore}</div>
+MyComponent.propTypes = propTypes.forbidUnknowProps({
+    score: propTypes.number,
+    maxScore: propTypes.number,
+})
+
+Note: `forbidUnknowProps` is different from the `exact` method form the standard
+prop-types library, because `forbidUnknowProps` is meant to be applied on a full component
+prop-type definition, while `exact` is meant to be a applied on an individual prop-type
 ```
 <a name="instanceOfComponent"></a>
 

--- a/src/forbidUnknownProps.js
+++ b/src/forbidUnknownProps.js
@@ -3,26 +3,26 @@
  * have been passed tot the component
  * @param {object} propTypes - The prop-types definition of the component
  * @return {Object} Returns a copy of the original prop-types object with an appended
- * property `forbidUnknowProps`, which is a prop-types validator that will return an error
+ * property `whitelistProps`, which is a prop-types validator that will return an error
  * if props have been added that the component that were not in the prop-types object
  * @example
  * import React from 'react'
  * import propTypes from '@dhis2/prop-types'
  *
  * const MyComponent = ({ score, maxScore }) => <div>{score} out of {maxScore}</div>
- * MyComponent.propTypes = propTypes.forbidUnknowProps({
+ * MyComponent.propTypes = propTypes.whitelistProps({
  *     score: propTypes.number,
  *     maxScore: propTypes.number,
  * })
  *
- * Note: `forbidUnknowProps` is different from the `exact` method form the standard
- * prop-types library, because `forbidUnknowProps` is meant to be applied on a full component
+ * Note: `whitelistProps` is different from the `exact` method form the standard
+ * prop-types library, because `whitelistProps` is meant to be applied on a full component
  * prop-type definition, while `exact` is meant to be a applied on an individual prop-type
  */
 
-const forbidUnknowProps = propTypes => ({
+const whitelistProps = propTypes => ({
     ...propTypes,
-    forbidUnknowProps: (props, _, componentName) => {
+    whitelistProps: (props, _, componentName) => {
         const unknownProps = Object.keys(props).filter(
             propKey => !propTypes[propKey]
         )
@@ -34,4 +34,4 @@ const forbidUnknowProps = propTypes => ({
     },
 })
 
-export { forbidUnknowProps }
+export { whitelistProps }

--- a/src/forbidUnknownProps.js
+++ b/src/forbidUnknownProps.js
@@ -1,0 +1,37 @@
+/**
+ * Ensure that no other props, apart from the ones in the prop-types definition
+ * have been passed tot the component
+ * @param {object} propTypes - The prop-types definition of the component
+ * @return {Object} Returns a copy of the original prop-types object with an appended
+ * property `forbidUnknowProps`, which is a prop-types validator that will return an error
+ * if props have been added that the component that were not in the prop-types object
+ * @example
+ * import React from 'react'
+ * import propTypes from '@dhis2/prop-types'
+ *
+ * const MyComponent = ({ score, maxScore }) => <div>{score} out of {maxScore}</div>
+ * MyComponent.propTypes = propTypes.forbidUnknowProps({
+ *     score: propTypes.number,
+ *     maxScore: propTypes.number,
+ * })
+ *
+ * Note: `forbidUnknowProps` is different from the `exact` method form the standard
+ * prop-types library, because `forbidUnknowProps` is meant to be applied on a full component
+ * prop-type definition, while `exact` is meant to be a applied on an individual prop-type
+ */
+
+const forbidUnknowProps = propTypes => ({
+    ...propTypes,
+    forbidUnknowProps: (props, _, componentName) => {
+        const unknownProps = Object.keys(props).filter(
+            propKey => !propTypes[propKey]
+        )
+        if (unknownProps.length > 0) {
+            const list = unknownProps.join(', ')
+            return new Error(`${componentName}: unknown props found: ${list}`)
+        }
+        return null
+    },
+})
+
+export { forbidUnknowProps }

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,23 @@
 import propTypes from 'prop-types'
 
 import { arrayWithLength } from './arrayWithLength.js'
+import { forbidUnknowProps } from './forbidUnknowProps.js'
 import { instanceOfComponent } from './instanceOfComponent.js'
 import { mutuallyExclusive } from './mutuallyExclusive.js'
 
 const customPropTypes = {
     arrayWithLength,
+    forbidUnknowProps,
     instanceOfComponent,
     mutuallyExclusive,
 }
 
-export { arrayWithLength, instanceOfComponent, mutuallyExclusive }
+export {
+    arrayWithLength,
+    forbidUnknowProps,
+    instanceOfComponent,
+    mutuallyExclusive,
+}
 
 export default {
     ...propTypes,

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,20 @@
 import propTypes from 'prop-types'
 
 import { arrayWithLength } from './arrayWithLength.js'
-import { forbidUnknowProps } from './forbidUnknowProps.js'
+import { whitelistProps } from './whitelistProps.js'
 import { instanceOfComponent } from './instanceOfComponent.js'
 import { mutuallyExclusive } from './mutuallyExclusive.js'
 
 const customPropTypes = {
     arrayWithLength,
-    forbidUnknowProps,
+    whitelistProps,
     instanceOfComponent,
     mutuallyExclusive,
 }
 
 export {
     arrayWithLength,
-    forbidUnknowProps,
+    whitelistProps,
     instanceOfComponent,
     mutuallyExclusive,
 }


### PR DESCRIPTION
I introduced this component because `propTypes.exact` does something slightly different than we needed....

For example this is how `propTypes.exact` is used:
```javascript
MyComponent.propTypes = {
    house: PropTypes.exact({
        streetName: PropTypes.string,
        houseNumber: PropTypes.number,
    }),
    otherProp: propTypes.bool,
}
```

And this would be a similar example of how this new function `forbidUnknowProps` can be used:
```javascript
MyComponent.propTypes = forbidUnknowProps({
    houseNumber: propTypes.number,
    streetName: propTypes.string,
    otherProps: propTypes.bool,
})
```

So with `forbidUnknowProps` we can wrap an entire prop-type definition and with `exact` we operate at property level.

As another note, normally we would export two "flavours": 1) the normal function and 2) the `isRequired` function. In this case that didn't make much sense....