### PR TITLE
fix(docs): build docs on pre-commit

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,8 +1,6 @@
 module.exports = {
     hooks: {
         'commit-msg': 'd2-style commit check',
-        'pre-commit': 'd2-style validate',
-        'pre-push':
-            'yarn docs && git add README.md && git commit --amend --no-edit',
+        'pre-commit': 'd2-style validate && yarn docs && git add README.md',
     },
 }


### PR DESCRIPTION
Prior to this fix the doc changes would not be included in the commit that was being pushed, so you'd have to manually push once more. Now the docs are included in the commit that is being pushed.