### PR TITLE
fix: improve instanceOfComponent robustness and remove incorrect logic

### DIFF
--- a/src/instanceOfComponent.js
+++ b/src/instanceOfComponent.js
@@ -9,26 +9,26 @@ const instanceOfComponentFactory = (Component, isRequired) => (
 ) => {
     const children = props[propSelector]
     const propName = propFullName || propSelector
-    const count = React.Children.count(children)
-    const isWrappedInArrayOf = !!propFullName
     const baseMsg = `Invalid prop \`${propName}\` supplied to \`${componentName}\`,`
 
-    if (isWrappedInArrayOf && count === 1 && children === '') {
-        // When mapping over an empty array to render components react will return ''
-        // So this is a valid case and should not produce an error
-        return null
-    }
-
-    if (isRequired && count === 0) {
+    if (Array.isArray(children)) {
         return new Error(
-            `${baseMsg} this is a required prop, but no component instance was found`
+            `${baseMsg} expected a single component instance but received an array.`
         )
     }
 
-    if (count > 1) {
-        return new Error(
-            `${baseMsg} expected 1 component instance, instead found ${count}.`
-        )
+    if (!children) {
+        if (isRequired) {
+            return new Error(
+                `${baseMsg} this is a required property but its value is \`${children}\`.`
+            )
+        } else {
+            return null
+        }
+    }
+
+    if (!React.isValidElement(children)) {
+        return new Error(`${baseMsg} not a valid React element.`)
     }
 
     if (children.type !== Component) {

--- a/src/mutuallyExclusive.js
+++ b/src/mutuallyExclusive.js
@@ -8,16 +8,9 @@ const mutuallyExclusiveFactory = (exlusivePropNames, propType, isRequired) => (
     propFullName // normally null but a string like "propName[index]" when wrapped in arrayOf
 ) => {
     const propName = propFullName || propSelector
-    const isWrappedInArrayOf = !!propFullName
     const baseMsg = `Invalid prop \`${propName}\` supplied to \`${componentName}\`,`
 
     // Usage errors
-    if (isWrappedInArrayOf) {
-        return new Error(
-            `mutuallyExclusive is being wrapped in \`arrayOf\` for property \`${propName}\` on component \`${componentName}\`. This is not supported.`
-        )
-    }
-
     if (exlusivePropNames.length === 0) {
         return new Error(
             `mutuallyExclusive was called without any arguments for property \`${propName}\` on component \`${componentName}\`. Please add the required arguments.`


### PR DESCRIPTION
- After a lot of debugging, it turns out that the the presence of a `propFullName` does not always mean the function was being called from the context of `arrayOf`. So I removed that logic from `instanceOfComponent` and `mutuallyExclusive`.
- I also found some problems with `instanceOfComponent`. A lot of things could go wrong:
    - Using `React.children.count` and then checking that this had a value of `1` was a bad idea because that function would return `1` for an array with length `1` as well as for a single component. Instead, I am now just throwing an error when we encounter an array.
    - In React there are quite a few falsy value that will render nothing (i.e. `false`, `null`, `undefined`, `""`). Since these are still valid children, the value of `count` would still be `1` if one of these was encountered. And as a result, we would then end up in the final condition, where it would try to read the `name` property of `children.type`. And since `children.type` was undefined, this would cause an error.

I can't think of any scenarios now that would cause this function from either producing a false positive or crashing.