### PR TITLE
feat: introduce requiredIf

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ also has a value, and ensure the prop is of the correct prop-type
 
 | Param | Type | Description |
 | --- | --- | --- |
-| siblingPropName | <code>string</code> | The name of the sibling prop |
+| siblingPropName | <code>function</code> | The name of the sibling prop |
 
 **Example**  
 ```js
@@ -149,6 +149,9 @@ const Test = ({ someBool, someString }) => (
 )
 Test.propTypes = {
     someBool: propTypes.bool,
-    someString: propTypes.requiredIf('someBool', propTypes.string),
+    someString: requiredIf(
+        ({ someBool, someString }) => someBool && !someString,
+        propTypes.string
+    ),
 }
 ```

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ If a third <code>propType</code> argument is passed each item in the array needs
 This function will also check if the current property value is of the specified type</p>
 </dd>
 <dt><a href="#requiredIf">requiredIf(siblingPropName)</a> ⇒ <code>Error</code> | <code>null</code></dt>
-<dd><p>Ensure the prop value is thruthy when a sibling prop also has a thruthy value,
-and ensure the prop is of the correct prop-type</p>
+<dd><p>Ensure the prop has a value (i.e. treat it as required) when a given sibling prop
+also has a value, and ensure the prop is of the correct prop-type</p>
 </dd>
 </dl>
 
@@ -126,8 +126,8 @@ Alert.propTypes = {
 <a name="requiredIf"></a>
 
 ## requiredIf(siblingPropName) ⇒ <code>Error</code> \| <code>null</code>
-Ensure the prop value is thruthy when a sibling prop also has a thruthy value,
-and ensure the prop is of the correct prop-type
+Ensure the prop has a value (i.e. treat it as required) when a given sibling prop
+also has a value, and ensure the prop is of the correct prop-type
 
 **Kind**: global function  
 **Returns**: <code>Error</code> \| <code>null</code> - Returns null if all conditions are met, or an error  

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ If a third <code>propType</code> argument is passed each item in the array needs
 <dd><p>Ensure that only one property within a specified list is thruthy
 This function will also check if the current property value is of the specified type</p>
 </dd>
+<dt><a href="#requiredIf">requiredIf(siblingPropName)</a> ⇒ <code>Error</code> | <code>null</code></dt>
+<dd><p>Ensure the prop value is thruthy when a sibling prop also has a thruthy value,
+and ensure the prop is of the correct prop-type</p>
+</dd>
 </dl>
 
 <a name="arrayWithLength"></a>
@@ -117,5 +121,34 @@ Alert.propTypes = {
     danger: statusPropType,
     warning: statusPropType,
     success: statusPropType,
+}
+```
+<a name="requiredIf"></a>
+
+## requiredIf(siblingPropName) ⇒ <code>Error</code> \| <code>null</code>
+Ensure the prop value is thruthy when a sibling prop also has a thruthy value,
+and ensure the prop is of the correct prop-type
+
+**Kind**: global function  
+**Returns**: <code>Error</code> \| <code>null</code> - Returns null if all conditions are met, or an error  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| siblingPropName | <code>string</code> | The name of the sibling prop |
+
+**Example**  
+```js
+import React from 'react'
+import { propTypes } from '@dhis2/prop-types'
+
+const Test = ({ someBool, someString }) => (
+    <div>
+        <h1>someBool: {someBool ? 'true' : 'false'}</h1>
+        <h1>someString: {someString}</h1>
+    </div>
+)
+Test.propTypes = {
+    someBool: propTypes.bool,
+    someString: propTypes.requiredIf('someBool', propTypes.string),
 }
 ```

--- a/README.md
+++ b/README.md
@@ -149,9 +149,6 @@ const Test = ({ someBool, someString }) => (
 )
 Test.propTypes = {
     someBool: propTypes.bool,
-    someString: requiredIf(
-        ({ someBool, someString }) => someBool && !someString,
-        propTypes.string
-    ),
+    someString: requiredIf(props => props.someBool, propTypes.string),
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,12 @@ import propTypes from 'prop-types'
 import { arrayWithLength } from './arrayWithLength.js'
 import { instanceOfComponent } from './instanceOfComponent.js'
 import { mutuallyExclusive } from './mutuallyExclusive.js'
+import { requiredIf } from './requiredIf.js'
 
 propTypes.arrayWithLength = arrayWithLength
 propTypes.instanceOfComponent = instanceOfComponent
 propTypes.mutuallyExclusive = mutuallyExclusive
+propTypes.requiredIf = requiredIf
 
 export { arrayWithLength, instanceOfComponent, mutuallyExclusive }
 export default propTypes

--- a/src/requiredIf.js
+++ b/src/requiredIf.js
@@ -1,0 +1,66 @@
+import propTypes from 'prop-types'
+
+const requiredIfFactory = (siblingPropName, propType, isRequired) => (
+    props,
+    propSelector, // normally a propName, but when wrapped in arrayOf an index
+    componentName,
+    _location,
+    propFullName // normally null but a string like "propName[index]" when wrapped in arrayOf
+) => {
+    const propName = propFullName || propSelector
+    const siblingPropValue = !!props[siblingPropName]
+    const propValue = props[propSelector]
+
+    // Usage errors
+    if (isRequired) {
+        return new Error(
+            `Property \`${propName}\` on component \`${componentName}\` is using the \`requiredIf\` prop-validator combined with \`.isRequired\`. This is an invalid combination.`
+        )
+    }
+
+    // Validation errors
+    if (siblingPropValue && !propValue) {
+        return new Error(
+            `Invalid prop \`${propName}\` supplied to \`${componentName}\`, this prop is required when \`${siblingPropName}\` is thruthy.`
+        )
+    }
+
+    // This is how to programatically invoke a propTypes check
+    // https://github.com/facebook/prop-types#proptypescheckproptypes
+    propTypes.checkPropTypes(
+        {
+            [propName]: propType,
+        },
+        props,
+        propName,
+        componentName
+    )
+
+    return null
+}
+
+/**
+ * Ensure the prop value is thruthy when a sibling prop also has a thruthy value,
+ * and ensure the prop is of the correct prop-type
+ * @param {string} siblingPropName - The name of the sibling prop
+ * @return {Error|null} Returns null if all conditions are met, or an error
+ * @example
+ * import React from 'react'
+ * import { propTypes } from '@dhis2/prop-types'
+ *
+ * const Test = ({ someBool, someString }) => (
+ *     <div>
+ *         <h1>someBool: {someBool ? 'true' : 'false'}</h1>
+ *         <h1>someString: {someString}</h1>
+ *     </div>
+ * )
+ * Test.propTypes = {
+ *     someBool: propTypes.bool,
+ *     someString: propTypes.requiredIf('someBool', propTypes.string),
+ * }
+ */
+export function requiredIf(siblingPropName, propType) {
+    const fn = requiredIfFactory(siblingPropName, propType, false)
+    fn.isRequired = requiredIfFactory(siblingPropName, propType, true)
+    return fn
+}

--- a/src/requiredIf.js
+++ b/src/requiredIf.js
@@ -70,10 +70,7 @@ const requiredIfFactory = (condition, propType, isRequired) => (
  * )
  * Test.propTypes = {
  *     someBool: propTypes.bool,
- *     someString: requiredIf(
- *         ({ someBool, someString }) => someBool && !someString,
- *         propTypes.string
- *     ),
+ *     someString: requiredIf(props => props.someBool, propTypes.string),
  * }
  */
 

--- a/src/requiredIf.js
+++ b/src/requiredIf.js
@@ -74,8 +74,8 @@ const requiredIfFactory = (condition, propType, isRequired) => (
  * }
  */
 
-export function requiredIf(siblingPropName, propType) {
-    const fn = requiredIfFactory(siblingPropName, propType, false)
-    fn.isRequired = requiredIfFactory(siblingPropName, propType, true)
+export function requiredIf(condition, propType) {
+    const fn = requiredIfFactory(condition, propType, false)
+    fn.isRequired = requiredIfFactory(condition, propType, true)
     return fn
 }

--- a/src/requiredIf.js
+++ b/src/requiredIf.js
@@ -1,5 +1,8 @@
 import propTypes from 'prop-types'
 
+const isEmpty = value =>
+    typeof value === 'undefined' || value === null || value === ''
+
 const requiredIfFactory = (siblingPropName, propType, isRequired) => (
     props,
     propSelector, // normally a propName, but when wrapped in arrayOf an index
@@ -8,8 +11,6 @@ const requiredIfFactory = (siblingPropName, propType, isRequired) => (
     propFullName // normally null but a string like "propName[index]" when wrapped in arrayOf
 ) => {
     const propName = propFullName || propSelector
-    const siblingPropValue = !!props[siblingPropName]
-    const propValue = props[propSelector]
 
     // Usage errors
     if (isRequired) {
@@ -19,9 +20,9 @@ const requiredIfFactory = (siblingPropName, propType, isRequired) => (
     }
 
     // Validation errors
-    if (siblingPropValue && !propValue) {
+    if (!isEmpty(props[siblingPropName]) && isEmpty(props[propSelector])) {
         return new Error(
-            `Invalid prop \`${propName}\` supplied to \`${componentName}\`, this prop is required when \`${siblingPropName}\` is thruthy.`
+            `Invalid prop \`${propName}\` supplied to \`${componentName}\`, this prop is required when \`${siblingPropName}\` has a value, but \`${propName}\` has value \`${props[propSelector]}\``
         )
     }
 
@@ -40,8 +41,8 @@ const requiredIfFactory = (siblingPropName, propType, isRequired) => (
 }
 
 /**
- * Ensure the prop value is thruthy when a sibling prop also has a thruthy value,
- * and ensure the prop is of the correct prop-type
+ * Ensure the prop has a value (i.e. treat it as required) when a given sibling prop
+ * also has a value, and ensure the prop is of the correct prop-type
  * @param {string} siblingPropName - The name of the sibling prop
  * @return {Error|null} Returns null if all conditions are met, or an error
  * @example


### PR DESCRIPTION
- Will throw a usage error if used in combination with `isRequired`
- Will throw a validation error if the validated prop has no value is but the sibling prop does
- Will throw a validation error if the validated prop has a value of the wrong type