### PR TITLE
feat: add conditional propType

### DIFF
--- a/src/__tests__/conditional.test.js
+++ b/src/__tests__/conditional.test.js
@@ -1,0 +1,72 @@
+import propTypes from 'prop-types'
+import { conditional } from '../conditional'
+
+describe('conditional', () => {
+    const propType = {
+        multiple: propTypes.bool,
+        selected: conditional(props =>
+            props.multiple
+                ? propTypes.arrayOf(propTypes.string)
+                : propTypes.string
+        ),
+    }
+
+    jest.spyOn(console, 'error').mockImplementation(() => null)
+    afterEach(() => console.error.mockClear())
+
+    describe('Valid', () => {
+        let props
+
+        afterEach(() => {
+            propTypes.checkPropTypes(
+                propType,
+                props,
+                'selected',
+                'TestComponent'
+            )
+
+            expect(console.error).toBeCalledTimes(0)
+        })
+
+        it('Multiple is false and selected is a stirng', () => {
+            props = {
+                multiple: false,
+                selected: 'foo',
+            }
+        })
+
+        it('Multiple is true and selected is a stirng-array', () => {
+            props = {
+                multiple: true,
+                selected: ['foo', 'bar'],
+            }
+        })
+    })
+
+    describe('Invalid', () => {
+        let props
+        // for some reason the checkPropTypes function does not print an error
+        // again if the error message AND the component name are identical
+        // So we need different component names
+        let componentName
+
+        afterEach(() => {
+            propTypes.checkPropTypes(propType, props, 'prop', componentName)
+            expect(console.error).toBeCalledTimes(1)
+        })
+
+        it('Multiple is true and selected is a string', () => {
+            props = {
+                multiple: true,
+                selected: 'foo',
+            }
+        })
+
+        it('Multiple is false and selected is a stirng-array', () => {
+            props = {
+                multiple: false,
+                selected: ['foo', 'bar'],
+            }
+        })
+    })
+})

--- a/src/conditional.js
+++ b/src/conditional.js
@@ -1,0 +1,80 @@
+import propTypes from 'prop-types'
+
+export const conditionalFactory = (propsToPropType, isRequired) => (
+    props,
+    propName,
+    componentName
+) => {
+    const isDefined = typeof props[propName] !== 'undefined'
+
+    if (typeof propsToPropType !== 'function') {
+        return new Error(
+            `The \`propsToPropType\` argument passed to the \`propsToPropTypeal\` prop-validator was not a function.`
+        )
+    }
+
+    const propType = propsToPropType(props)
+
+    if (typeof propType !== 'function') {
+        return new Error(
+            `The response of \`propsToPropType\` call with the props was not a function.`
+        )
+    }
+
+    // Validation errors
+    if (isRequired && !isDefined) {
+        return new Error(
+            `Invalid prop \`${propName}\` supplied to \`${componentName}\`, this prop is required but no value was found.`
+        )
+    }
+
+    propTypes.checkPropTypes(
+        { [propName]: propType },
+        props,
+        'prop',
+        componentName
+    )
+
+    return null
+}
+
+/**
+ * Uses either one or another propType, based on the result of the
+ * propsToPropType callback, called with the props
+ *
+ * @param {Function} propsToPropType - A callback for determining which propType to use
+ * @param {Function} eitherPropType
+ * @param {Function} orPropType
+ * @return {Error|null} Returns null if all propsToPropTypes are met, or an error
+ *
+ * @example
+ * import React from 'react'
+ * import { propsToPropTypeal } from '@dhis2/prop-types'
+ *
+ * const List = ({ multiple, selected, items }) => (
+ *     const selectedItems = multiple ? selected : [selected]
+ *
+ *     <div>
+ *         {items.map(item => (
+ *             <li className={selectedItems.includes(item) ? 'active' : ''}>
+ *                 {item}
+ *             </li>
+ *         ))}
+ *     </div>
+ * )
+ *
+ * List.propTypes = {
+ *     multiple: propTypes.bool,
+ *     items: props.arrayOf(prpoTypes.string),
+ *     selected: propsToPropTypeal(
+ *         props => propTypes.multiple
+ *           ? propTypes.arrayOf(prpoTypes.string)
+ *           : propTypes.string,
+ *     ),
+ * }
+ */
+export const conditional = propsToPropType => {
+    const fn = conditionalFactory(propsToPropType, false)
+    fn.isRequired = conditionalFactory(propsToPropType, true)
+    return fn
+}


### PR DESCRIPTION
This is the counterpiece to `oneOfType`. While `oneOfType` allows all supplied propTypes, `conditional` will pick a propType based on the result of a condition callback.

```js
const Component = ({ multiple, selected, optons }) => {
  const selectedOptions = multiple ? selected : [selected]

  return // jsx
}

Component.propTypes = {
  multiple: propTypes.bool,
  selected: conditional(({ multiple }) => multiple
    ? propTypes.arrayOf(propTypes.string)
    : propTypes.string
  ),
}
```