### PR TITLE
refactor: export all prop-types as a default export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,12 @@
 import propTypes from 'prop-types'
-
 import { arrayWithLength } from './propTypes/arrayWithLength.js'
 import { conditional } from './propTypes/conditional'
 import { instanceOfComponent } from './propTypes/instanceOfComponent.js'
 import { mutuallyExclusive } from './propTypes/mutuallyExclusive.js'
 import { requiredIf } from './propTypes/requiredIf.js'
 
-propTypes.arrayWithLength = arrayWithLength
-propTypes.conditional = conditional
-propTypes.instanceOfComponent = instanceOfComponent
-propTypes.mutuallyExclusive = mutuallyExclusive
-propTypes.requiredIf = requiredIf
-
-export {
+const dhis2PropTypes = {
+    ...propTypes,
     arrayWithLength,
     conditional,
     instanceOfComponent,
@@ -20,4 +14,4 @@ export {
     requiredIf,
 }
 
-export default propTypes
+export default dhis2PropTypes


### PR DESCRIPTION
This allows our lib to be a drop-in replacement for apps that import their prop-types like so:

```
import { func } from 'prop-types'
```

I've written a test to ensure that we don't overwrite existing prop-types. I've also created a new object for the export instead of mutating prop-types, since otherwise the prop-types package would already contain our custom prop-types (and I couldn't test if we'd overwritten anything), plus it seems safer in general.

I rewrote the existing tests slightly to make them (in my opinion) easier to understand. But let me know if you disagree, since it needs to be easy to understand for everyone.