### PR TITLE
fix: export named and default exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,14 @@
 import propTypes from 'prop-types'
-import { arrayWithLength } from './propTypes/arrayWithLength.js'
-import { conditional } from './propTypes/conditional'
-import { instanceOfComponent } from './propTypes/instanceOfComponent.js'
-import { mutuallyExclusive } from './propTypes/mutuallyExclusive.js'
-import { requiredIf } from './propTypes/requiredIf.js'
+import * as customPropTypes from './propTypes'
 
-const dhis2PropTypes = {
+// Export all prop-types as named exports
+export * from './propTypes'
+export * from 'prop-types'
+
+// Export all prop-types as a default export as well
+const allPropTypes = {
     ...propTypes,
-    arrayWithLength,
-    conditional,
-    instanceOfComponent,
-    mutuallyExclusive,
-    requiredIf,
+    ...customPropTypes,
 }
 
-export default dhis2PropTypes
+export default allPropTypes

--- a/src/propTypes/index.js
+++ b/src/propTypes/index.js
@@ -1,0 +1,5 @@
+export { arrayWithLength } from './arrayWithLength.js'
+export { conditional } from './conditional'
+export { instanceOfComponent } from './instanceOfComponent.js'
+export { mutuallyExclusive } from './mutuallyExclusive.js'
+export { requiredIf } from './requiredIf.js'


### PR DESCRIPTION
Slight hitch in my assumption for #125. Default exports cannot be directly destructured, which makes sense of course. So we need to have a default export, plus named exports, if we want to support both import styles that 'prop-types' supports.