### PR TITLE
feat: update the export style

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 import fs from 'fs'
 import path from 'path'
-import originalPropTypes from 'prop-types'
 import dhis2PropTypes, * as namedDhis2PropTypes from '../index.js'
 
 const customPropTypesPath = path.join(__dirname, '../propTypes')
@@ -36,12 +35,6 @@ describe('default export', () => {
             expect(exportedPropType).toBe(dhis2PropTypes[filename])
         })
     })
-
-    it('should not overwrite existing prop-types in the prop-types package', () => {
-        Object.keys(originalPropTypes).forEach(propType => {
-            expect(dhis2PropTypes[propType]).toBe(originalPropTypes[propType])
-        })
-    })
 })
 
 describe('named exports', () => {
@@ -60,14 +53,6 @@ describe('named exports', () => {
             const exportedPropType = exportedModule[filename]
 
             expect(exportedPropType).toBe(namedDhis2PropTypes[filename])
-        })
-    })
-
-    it('should not overwrite existing prop-types in the prop-types package', () => {
-        Object.keys(originalPropTypes).forEach(propType => {
-            expect(namedDhis2PropTypes[propType]).toBe(
-                originalPropTypes[propType]
-            )
         })
     })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,22 @@
-import propTypes from 'prop-types'
+import PropTypes from 'prop-types'
 import * as customPropTypes from './propTypes'
 
-// Export all prop-types as named exports
+/*
+ * Export our own prop-types as named exports, this allows this import style:
+ * import { arrayWithLength } from '@dhis2/prop-types'
+ */
 export * from './propTypes'
-export * from 'prop-types'
 
-// Export all prop-types as a default export as well
-const allPropTypes = {
-    ...propTypes,
-    ...customPropTypes,
-}
+/*
+ * Reexport the prop-types lib under a namespace, as is our convention. The
+ * name is Pascalcased, this allows for this import style:
+ * import { PropTypes } from '@dhis2/prop-types'
+ */
+export { PropTypes }
 
-export default allPropTypes
+/*
+ * Export custom prop-types as the default export. This only contains our
+ * own prop-types. Import style is (naming is up to the user of course):
+ * import dhis2PropTypes from '@dhis2/prop-types'
+ */
+export default customPropTypes


### PR DESCRIPTION
BREAKING CHANGE: this changes the re-export style for the prop-types lib. Instead of mixing our custom and the upstream prop-types, now the upstream lib is namespaced under the 'PropTypes' named export.

Note: I've removed the tests that were checking if we're overwriting named exports, because due to the namespacing we no longer _can_ overwrite anything. The only thing we could potentially overwrite is the named `PropTypes` export, but that would be tough to do since it comes after our own named exports, so I think that that doesn't seem necessary to test.