### PR TITLE
feat: add deprecated prop decorator

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
         "test": "d2-app-scripts test",
         "docs": "jsdoc2md -t jsdoc2md/README.hbs src/*.js > README.md; echo",
         "build": "d2-app-scripts build",
+        "format": "yarn format:js && yarn format:text",
+        "format:js": "d2-style check js",
+        "format:text": "d2-style check text",
         "lint": "yarn lint:js && yarn lint:text",
         "lint:js": "d2-style check js",
         "lint:text": "d2-style check text"

--- a/src/__tests__/deprecated.test.js
+++ b/src/__tests__/deprecated.test.js
@@ -1,0 +1,118 @@
+import propTypes from 'prop-types'
+import { deprecated } from '../deprecated'
+
+describe('deprecated', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => null)
+    jest.spyOn(console, 'warn').mockImplementation(() => null)
+
+    afterEach(() => {
+        console.error.mockClear()
+        console.warn.mockClear()
+    })
+
+    it('warns when props are valid', () => {
+        const propType = {
+            deprecatedBool: deprecated(
+                propTypes.bool,
+                'Please do not use anymore'
+            ),
+        }
+        const props = {
+            deprecatedBool: false,
+        }
+
+        propTypes.checkPropTypes(
+            propType,
+            props,
+            'deprecatedMandatoryBool',
+            'TestComponent'
+        )
+
+        expect(console.error).toBeCalledTimes(0)
+        expect(console.warn).toBeCalledTimes(1)
+    })
+    it('warns when props are invalid', () => {
+        const propType = {
+            deprecatedBool: deprecated(
+                propTypes.bool,
+                'Please do not use anymore'
+            ),
+        }
+        const props = {
+            deprecatedBool: 'I aint no bool',
+        }
+
+        propTypes.checkPropTypes(
+            propType,
+            props,
+            'deprecatedBool',
+            'TestComponent'
+        )
+
+        expect(console.error).toBeCalledTimes(1)
+        expect(console.warn).toBeCalledTimes(1)
+    })
+    it('produces one warning per deprecated prop', () => {
+        const propType = {
+            a: deprecated(propTypes.bool, 'Please do not use anymore'),
+            b: deprecated(propTypes.bool, 'Please do not use anymore'),
+            c: deprecated(propTypes.bool, 'Please do not use anymore'),
+        }
+        const props = {
+            a: true,
+            b: true,
+            c: true,
+        }
+
+        propTypes.checkPropTypes(
+            propType,
+            props,
+            'deprecatedBool',
+            'TestComponent'
+        )
+
+        expect(console.error).toBeCalledTimes(0)
+        expect(console.warn).toBeCalledTimes(3)
+
+        expect(console.warn).toHaveBeenCalledWith(
+            '"a" property of "TestComponent" has been deprecated. Please do not use anymore'
+        )
+        expect(console.warn).toHaveBeenCalledWith(
+            '"b" property of "TestComponent" has been deprecated. Please do not use anymore'
+        )
+        expect(console.warn).toHaveBeenCalledWith(
+            '"c" property of "TestComponent" has been deprecated. Please do not use anymore'
+        )
+    })
+
+    it('does not repeat warnings when props are re-validated', () => {
+        const spy = jest.spyOn(propTypes, 'checkPropTypes')
+        const propType = {
+            deprecatedBool: deprecated(
+                propTypes.bool,
+                'Please do not use anymore'
+            ),
+        }
+        const props = {
+            deprecatedBool: 'I aint no bool',
+        }
+
+        propTypes.checkPropTypes(
+            propType,
+            props,
+            'deprecatedBool',
+            'TestComponent'
+        )
+        propTypes.checkPropTypes(
+            propType,
+            props,
+            'deprecatedBool',
+            'TestComponent'
+        )
+
+        // Can't explain why the spy is called 4 times, but at least
+        // this does verify that the warning will only be showed once
+        expect(spy).toBeCalledTimes(4)
+        expect(console.warn).toBeCalledTimes(1)
+    })
+})

--- a/src/__tests__/deprecated.test.js
+++ b/src/__tests__/deprecated.test.js
@@ -1,5 +1,5 @@
 import propTypes from 'prop-types'
-import { deprecated } from '../deprecated'
+import { deprecated } from '../deprecated.js'
 
 describe('deprecated', () => {
     jest.spyOn(console, 'error').mockImplementation(() => null)

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -1,0 +1,23 @@
+import propTypes from 'prop-types'
+
+export const deprecated = (propType, explanation) => {
+    const emmittedWarnings = new Set()
+
+    return (props, propName, componentName) => {
+        const message = `"${propName}" property of "${componentName}" has been deprecated. ${explanation}`
+
+        if (!emmittedWarnings.has(message)) {
+            console.warn(message)
+            emmittedWarnings.add(message)
+        }
+
+        propTypes.checkPropTypes(
+            { [propName]: propType },
+            props,
+            'prop',
+            componentName
+        )
+
+        return null
+    }
+}


### PR DESCRIPTION
I've called this a prop-decorator because it doesn't actually do any validation. Still think it's a good addition to our lib.