### PR TITLE
fix(deprecated): show warning only if prop is populated

### DIFF
--- a/src/__tests__/deprecated.test.js
+++ b/src/__tests__/deprecated.test.js
@@ -115,4 +115,25 @@ describe('deprecated', () => {
         expect(spy).toBeCalledTimes(4)
         expect(console.warn).toBeCalledTimes(1)
     })
+    it('does not produce a warning when the deprecated prop is not passed', () => {
+        const propType = {
+            deprecatedBool: deprecated(
+                propTypes.bool,
+                'Please do not use anymore'
+            ),
+        }
+        const props = {
+            deprecatedBool: undefined,
+        }
+
+        propTypes.checkPropTypes(
+            propType,
+            props,
+            'deprecatedMandatoryBool',
+            'TestComponent'
+        )
+
+        expect(console.error).toBeCalledTimes(0)
+        expect(console.warn).toBeCalledTimes(0)
+    })
 })

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -6,7 +6,10 @@ export const deprecated = (propType, explanation) => {
     return (props, propName, componentName) => {
         const message = `"${propName}" property of "${componentName}" has been deprecated. ${explanation}`
 
-        if (!emmittedWarnings.has(message)) {
+        if (
+            typeof props[propName] !== 'undefined' &&
+            !emmittedWarnings.has(message)
+        ) {
             console.warn(message)
             emmittedWarnings.add(message)
         }


### PR DESCRIPTION
Quite a large oversight: the warning here was showing also when the prop was not populated. Fixed now, with test.